### PR TITLE
Update title fields in docs/README.md (release-v0.14.x patch)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,11 @@
 <!-- prettier-ignore start -->
 <!--
 ---
-title: "Overview of Tekton Triggers"
-linkTitle: "Overview"
+title: "Triggers and EventListeners"
+linkTitle: "Triggers and EventListeners"
 weight: 3
 description: >
-  Tekton Triggers
+  Event Based Triggers for Tekton Pipelines
 cascade:
   github_project_repo: https://github.com/tektoncd/triggers
 ---
@@ -14,7 +14,7 @@ cascade:
 <!-- prettier-ignore end -->
 
 
-# Overview of Tekton Triggers
+# Tekton Triggers
 
 Tekton Triggers is a Tekton component that allows you to detect and extract information from events from a variety of sources and deterministically instantiate
 and execute [`TaskRuns`](https://github.com/tektoncd/pipeline/blob/master/docs/taskruns.md) and [`PipelineRuns`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md)
@@ -26,27 +26,27 @@ cluster as an extension to Tekton Pipelines.
 Tekton Triggers consists of a controller service that runs on your Kubernetes cluster as well as the following Kubernetes Custom Resource Definitions (CRDs) that extend
 the functionality of Tekton Pipelines to support events:
 
-*  [`EventListener`](https://github.com/tektoncd/triggers/blob/main/docs/eventlisteners.md) - listens for events at a specified port on your Kubernetes cluster.
+*  [`EventListener`](eventlisteners.md) - listens for events at a specified port on your Kubernetes cluster.
    Specifies one or more `Triggers`.
 
-*  [`Trigger`](https://github.com/tektoncd/triggers/blob/main/docs/triggers.md) - specifies what happens when the `EventListener` detects an event. A `Trigger` specifies
+*  [`Trigger`](triggers.md) - specifies what happens when the `EventListener` detects an event. A `Trigger` specifies
    a `TriggerTemplate`, a `TriggerBinding`, and optionally, an `Interceptor`.
 
-*  [`TriggerTemplate`](https://github.com/tektoncd/triggers/blob/main/docs/triggertemplates.md) - specifies a blueprint for the resource, such as a `TaskRun` or `PipelineRun`,
+*  [`TriggerTemplate`](triggertemplates.md) - specifies a blueprint for the resource, such as a `TaskRun` or `PipelineRun`,
    that you want to instantiate and/or execute when your `EventListener` detects an event. It exposes parameters that you can use anywhere within your resource's template.
 
-*  [`TriggerBinding`](https://github.com/tektoncd/triggers/blob/main/docs/triggerbindings.md) - specifies the fields in the event payload from which you want to extract
+*  [`TriggerBinding`](triggerbindings.md) - specifies the fields in the event payload from which you want to extract
    data and the fields in your corresponding `TriggerTemplate` to populate with the extracted values. You can then use the populated fields in the `TriggerTemplate` to
    populate fields in the associated `TaskRun` or `PipelineRun`.
 
-*  [`ClusterTriggerBinding`](https://github.com/tektoncd/triggers/blob/main/docs/triggerbindings.md) - a cluster-scoped version of the `TriggerBinding`,
+*  [`ClusterTriggerBinding`](triggerbindings.md) - a cluster-scoped version of the `TriggerBinding`,
    especially useful for reuse within your cluster.
 
 *  [`Interceptor`](interceptors.md) - a "catch-all" event processor for a specific platform that
    runs before the `TriggerBinding` enabling you to perform payload filtering, verification (using a secret), transformation, define and test trigger conditions, and other
    useful processing. Once the event data passes through an interceptor, it then goes to the `Trigger` before you pass the payload data to the `TriggerBinding`.
 
-   **Note:** `Interceptors` are currently part of `EventListeners` but are being converted to a standalond CRD in [PR 960](https://github.com/tektoncd/triggers/pull/960). 
+   **Note:** `Interceptors` are currently part of `EventListeners` but are being converted to a standalond CRD in [PR 960](https://github.com/tektoncd/triggers/pull/960).
 
 
 ## What can I do with Triggers?
@@ -67,7 +67,7 @@ As an example, you can implement the following CI/CD workflow with Triggers:
 
 To get started with Tekton Triggers, see the following:
 
-*   [Setting Up Tekton Triggers](https://github.com/tektoncd/triggers/blob/main/docs/install.md)
+*   [Setting Up Tekton Triggers](install.md)
 *   [Getting Started with Tekton Triggers](https://github.com/tektoncd/triggers/blob/main/docs/getting-started/README.md)
 *   [Tekton Triggers code examples](https://github.com/tektoncd/triggers/tree/main/examples)
-*   [Troubleshooting Tekton Triggers](https://github.com/tektoncd/triggers/blob/main/docs/troubleshooting.md)
+*   [Troubleshooting Tekton Triggers](troubleshooting.md)


### PR DESCRIPTION
# Changes

Use more appropriate values for the title fields in the frontmatter of README.md. In the context of the sidebar navigation of the website, for example, 'Overview' is too generic.

See #1095 for more background.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [:no_good_man:] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#tests) (if functionality changed/added)
- [:no_good_man:] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commits)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

